### PR TITLE
Update to 1.17 and rework Autoconfig to use Jankson

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,10 +10,10 @@ plugins {
 
 ext {
 	commonGradleBranch = "master"
-	minecraftVersion = "1.17"
-	yarnMappings = "1.17+build.13"
-	loaderVersion = "0.11.3"
-	fabricAPIVersion = "0.36.0+1.17"
+	minecraftVersion = "1.17.1"
+	yarnMappings = "1.17.1+build.14"
+	loaderVersion = "0.11.6"
+	fabricAPIVersion = "0.37.0+1.17"
 	clothConfigVersion = "5.0.34"
 	modMenuVersion = "2.0.2"
 	autoConfigVersion = "3.3.1"

--- a/build.gradle
+++ b/build.gradle
@@ -2,28 +2,27 @@ import com.modrinth.minotaur.TaskModrinthUpload
 
 plugins {
 	id "java-library"
-	id "fabric-loom" version "0.5-SNAPSHOT"
+	id "fabric-loom" version "0.8-SNAPSHOT"
 	id "com.matthewprenger.cursegradle" version "1.4.0"
-	id "com.modrinth.minotaur" version "1.1.0"
+	id "com.modrinth.minotaur" version "1.2.1"
+	id "org.cadixdev.licenser" version "0.6.1"
 }
 
 ext {
 	commonGradleBranch = "master"
-	minecraftVersion = "1.16.5"
-	yarnMappings = "1.16.5+build.1"
-	loaderVersion = "0.11.1"
-	fabricAPIVersion = "0.29.3+1.16"
-	modMenuVersion = "1.14.13+build.19"
-	clothConfigVersion = "4.8.3"
+	minecraftVersion = "1.17"
+	yarnMappings = "1.17+build.13"
+	loaderVersion = "0.11.3"
+	fabricAPIVersion = "0.36.0+1.17"
+	clothConfigVersion = "5.0.34"
+	modMenuVersion = "2.0.2"
 	autoConfigVersion = "3.3.1"
-	autoConfigTOMLVersion = "autoconfig-3.x.x-fabric-SNAPSHOT"
 }
-
-version = "2.0.6-fabric"
+version = "2.1.0-fabric"
 group = "com.therandomlabs.vanilladeathchest"
 archivesBaseName = "vanilladeathchest"
 
-apply from: "https://raw.githubusercontent.com/TheRandomLabs/Common-Gradle/${project.commonGradleBranch}/fabric.gradle"
+apply from: "https://raw.githubusercontent.com/jhbuchanan45/Common-Gradle/main/fabric.gradle"
 
 if (project.hasProperty("curseForgeAPIKey")) {
 	curseforge {
@@ -33,14 +32,8 @@ if (project.hasProperty("curseForgeAPIKey")) {
 			id = "393000"
 
 			addGameVersion "Fabric"
-			addGameVersion "Java 10"
-			addGameVersion "Java 9"
-			addGameVersion "Java 8"
-			addGameVersion "1.16.5"
-			addGameVersion "1.16.4"
-			addGameVersion "1.16.3"
-			addGameVersion "1.16.2"
-			addGameVersion "1.16.1"
+			addGameVersion "Java 16"
+			addGameVersion "1.17.0"
 
 			mainArtifact(remapJar) {
 				changelogType = "markdown"
@@ -83,11 +76,7 @@ if (project.hasProperty("modrinthToken")) {
 		changelog = new File("changelog.md").getText()
 		uploadFile = remapJar
 		releaseType = "alpha"
-		addGameVersion("1.16.5")
-		addGameVersion("1.16.4")
-		addGameVersion("1.16.3")
-		addGameVersion("1.16.2")
-		addGameVersion("1.16.1")
+		addGameVersion("1.17.0")
 		addLoader("fabric")
 		addFile(sourcesJar)
 		addFile(javadocJar)

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ import com.modrinth.minotaur.TaskModrinthUpload
 
 plugins {
 	id "java-library"
-	id "fabric-loom" version "0.9-SNAPSHOT"
+	id "fabric-loom" version "0.9.+"
 	id "com.matthewprenger.cursegradle" version "1.4.0"
 	id "com.modrinth.minotaur" version "1.2.1"
 	id "org.cadixdev.licenser" version "0.6.1"
@@ -11,7 +11,7 @@ plugins {
 ext {
 	commonGradleBranch = "master"
 	minecraftVersion = "1.17.1"
-	yarnMappings = "1.17.1+build.14"
+	yarnMappings = "1.17.1+build.40"
 	loaderVersion = "0.11.6"
 	fabricAPIVersion = "0.37.0+1.17"
 	clothConfigVersion = "5.0.34"

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ import com.modrinth.minotaur.TaskModrinthUpload
 
 plugins {
 	id "java-library"
-	id "fabric-loom" version "0.8-SNAPSHOT"
+	id "fabric-loom" version "0.9-SNAPSHOT"
 	id "com.matthewprenger.cursegradle" version "1.4.0"
 	id "com.modrinth.minotaur" version "1.2.1"
 	id "org.cadixdev.licenser" version "0.6.1"
@@ -34,6 +34,7 @@ if (project.hasProperty("curseForgeAPIKey")) {
 			addGameVersion "Fabric"
 			addGameVersion "Java 16"
 			addGameVersion "1.17.0"
+			addGameVersion "1.17.1"
 
 			mainArtifact(remapJar) {
 				changelogType = "markdown"
@@ -77,6 +78,7 @@ if (project.hasProperty("modrinthToken")) {
 		uploadFile = remapJar
 		releaseType = "alpha"
 		addGameVersion("1.17.0")
+		addGameVersion("1.17.1")
 		addLoader("fabric")
 		addFile(sourcesJar)
 		addFile(javadocJar)

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/com/therandomlabs/vanilladeathchest/VDCConfig.java
+++ b/src/main/java/com/therandomlabs/vanilladeathchest/VDCConfig.java
@@ -23,394 +23,41 @@
 
 package com.therandomlabs.vanilladeathchest;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
 import java.util.Random;
-import java.util.Set;
-import java.util.stream.Collectors;
 
-import com.electronwill.nightconfig.core.conversion.SpecDoubleInRange;
-import com.electronwill.nightconfig.core.conversion.SpecIntInRange;
-import com.mojang.brigadier.exceptions.CommandSyntaxException;
-import com.therandomlabs.autoconfigtoml.TOMLConfigSerializer;
-import me.sargunvohra.mcmods.autoconfig1u.ConfigData;
-import me.sargunvohra.mcmods.autoconfig1u.annotation.Config;
-import me.sargunvohra.mcmods.autoconfig1u.annotation.ConfigEntry;
-import net.minecraft.entity.Entity;
-import net.minecraft.entity.EntityType;
-import net.minecraft.item.Item;
-import net.minecraft.item.Items;
-import net.minecraft.nbt.StringNbtReader;
+import com.therandomlabs.vanilladeathchest.config.DefenseEntities;
+import com.therandomlabs.vanilladeathchest.config.KeyItem;
+import com.therandomlabs.vanilladeathchest.config.Misc;
+import com.therandomlabs.vanilladeathchest.config.Protection;
+import com.therandomlabs.vanilladeathchest.config.Spawning;
+import me.shedaniel.autoconfig.annotation.Config;
+import me.shedaniel.autoconfig.annotation.ConfigEntry;
+import me.shedaniel.autoconfig.serializer.PartitioningSerializer;
 import net.minecraft.util.DyeColor;
-import net.minecraft.util.Identifier;
-import net.minecraft.util.registry.Registry;
-import net.minecraft.world.World;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 @SuppressWarnings("CanBeFinal")
-@TOMLConfigSerializer.Comment("VanillaDeathChest configuration.")
 @Config(name = VanillaDeathChest.MOD_ID)
-public final class VDCConfig implements ConfigData {
-	public static final class Spawning implements ConfigData {
-		@TOMLConfigSerializer.Comment({
-				"The death chest container type.",
-				"SINGLE_CHEST: Only single chests.",
-				"SINGLE_OR_DOUBLE_CHEST: Single or double chests.",
-				"SINGLE_SHULKER_BOX: Single shulker boxes.",
-				"SINGLE_OR_DOUBLE_SHULKER_BOX: Single or double shulker boxes."
-		})
-		@ConfigEntry.Gui.Tooltip
-		public ContainerType containerType = ContainerType.SINGLE_OR_DOUBLE_CHEST;
+public final class VDCConfig extends PartitioningSerializer.GlobalData {
+	@ConfigEntry.Category("spawning")
+	@ConfigEntry.Gui.TransitiveObject
+	public Spawning spawning = new Spawning();
 
-		@TOMLConfigSerializer.Comment({
-				"The color of the shulker box if the container type is a shulker box.",
-				"WHITE: White.",
-				"ORANGE: Orange.",
-				"MAGENTA: Magenta.",
-				"LIGHT_BLUE: Light blue.",
-				"YELLOW: Yellow.",
-				"LIME: Lime.",
-				"PINK: Pink.",
-				"GRAY: Gray.",
-				"LIGHT_GRAY: Light gray.",
-				"CYAN: Cyan.",
-				"PURPLE: Purple.",
-				"BLUE: Blue.",
-				"BROWN: Brown.",
-				"GREEN: Green.",
-				"RED: Red.",
-				"BLACK: Black.",
-				"RANDOM: Random color."
-		})
-		@ConfigEntry.Gui.Tooltip
-		public ShulkerBoxColor shulkerBoxColor = ShulkerBoxColor.WHITE;
+	@ConfigEntry.Category("key_item")
+	@ConfigEntry.Gui.TransitiveObject
+	public KeyItem keyItem = new KeyItem();
 
-		@TOMLConfigSerializer.Comment(
-				"The dimensions that death chests should or should not spawn in."
-		)
-		@ConfigEntry.Gui.Tooltip
-		public List<String> dimensions = new ArrayList<>();
+	@ConfigEntry.Category("defense_entities")
+	@ConfigEntry.Gui.TransitiveObject
+	public DefenseEntities defenseEntities = new DefenseEntities();
 
-		@TOMLConfigSerializer.Comment({
-				"Whether the dimensions list should be a blacklist or a whitelist.",
-				"BLACKLIST: blacklist.",
-				"WHITELIST: whitelist."
-		})
-		@ConfigEntry.Gui.Tooltip
-		public DimensionListBehavior dimensionsBehavior = DimensionListBehavior.BLACKLIST;
+	@ConfigEntry.Category("protection")
+	@ConfigEntry.Gui.TransitiveObject
+	public Protection protection = new Protection();
 
-		@SpecIntInRange(min = 1, max = Integer.MAX_VALUE)
-		@TOMLConfigSerializer.Comment(
-				"The radius around the location of a player's death in which a suitable death " +
-						"chest placement location should be searched for."
-		)
-		@ConfigEntry.Gui.Tooltip
-		public int locationSearchRadius = 8;
-
-		@TOMLConfigSerializer.Comment(
-				"Causes a death chest to be forcibly placed at the location of a player's death " +
-						"if no suitable locations are found nearby."
-		)
-		@ConfigEntry.Gui.Tooltip
-		public boolean forcePlacementIfNoSuitableLocation = true;
-
-		@TOMLConfigSerializer.Comment("Requires death chest placement to be on solid blocks.")
-		@ConfigEntry.Gui.Tooltip
-		public boolean requirePlacementOnSolidBlocks;
-
-		@TOMLConfigSerializer.Comment(
-				"A regular expression that matches the registry names of items that can be " +
-						"placed in death chests."
-		)
-		@ConfigEntry.Gui.Tooltip
-		public String registryNameRegex = ".+";
-
-		@TOMLConfigSerializer.Comment({
-				"Causes death chests to only be spawned if the necessary container is in the " +
-						"player's inventory.",
-				"If this is enabled, the container is consumed if it is found."
-		})
-		@ConfigEntry.Gui.Tooltip
-		public boolean useContainerInInventory;
-
-		@TOMLConfigSerializer.Comment({
-				"The display name of the death chest container.",
-				"Set this to an empty string to cause a custom display name to not be used."
-		})
-		@ConfigEntry.Gui.Tooltip
-		public String containerDisplayName = "Death Chest";
-
-		@TOMLConfigSerializer.Comment({
-				"The message sent to a player after a death chest is placed when they die.",
-				"The X, Y and Z coordinates are provided as arguments.",
-				"Set this to an empty string to disable this message."
-		})
-		@ConfigEntry.Gui.Tooltip
-		public String spawnMessage = "Death chest spawned at [%s, %s, %s]";
-
-		@Nullable
-		@ConfigEntry.Gui.Excluded
-		private Set<Identifier> dimensionIdentifiers;
-
-		/**
-		 * {@inheritDoc}
-		 */
-		@Override
-		public void validatePostLoad() {
-			dimensionIdentifiers = dimensions.stream().
-					map(Identifier::new).
-					collect(Collectors.toSet());
-			dimensions = dimensionIdentifiers.stream().
-					map(Identifier::toString).
-					collect(Collectors.toList());
-		}
-
-		/**
-		 * Returns whether death chest spawning is enabled in the specified world's dimension.
-		 *
-		 * @param world a {@link World}.
-		 * @return {@code true} if death chest spawning is enabled in the specified dimension,
-		 * or otherwise {@code false}.
-		 */
-		@SuppressWarnings({"ConstantConditions", "NullAway"})
-		public boolean isDimensionEnabled(World world) {
-			final Identifier identifier = world.getRegistryManager().
-					get(Registry.DIMENSION_TYPE_KEY).
-					getId(world.getDimension());
-
-			if (identifier == null) {
-				VanillaDeathChest.logger.error(
-						"Failed to determine dimension", new RuntimeException()
-				);
-				return dimensionsBehavior == DimensionListBehavior.BLACKLIST;
-			}
-
-			final boolean anyMatch = dimensionIdentifiers.stream().anyMatch(identifier::equals);
-
-			if (dimensionsBehavior == DimensionListBehavior.BLACKLIST) {
-				return !anyMatch;
-			}
-
-			return anyMatch;
-		}
-	}
-
-	public static final class KeyItem implements ConfigData {
-		@TOMLConfigSerializer.Comment({
-				"The registry name of the key item.",
-				"A player must be holding this item in their main hand to unlock a death chest.",
-				"Set this to an empty string to allow death chests to be unlocked without an item."
-		})
-		@ConfigEntry.Gui.Tooltip
-		public String registryName = "";
-
-		@SpecIntInRange(min = 0, max = Short.MAX_VALUE)
-		@TOMLConfigSerializer.Comment({
-				"The meta value of the key item.",
-				"Set this to " + Short.MAX_VALUE + " to not require a specific meta value."
-		})
-		@ConfigEntry.Gui.Tooltip
-		public int meta = Short.MAX_VALUE;
-
-		@TOMLConfigSerializer.Comment({
-				"The key consumption behavior.",
-				"CONSUME: Consume the item.",
-				"DAMAGE: Damage the item."
-		})
-		@ConfigEntry.Gui.Tooltip
-		public KeyConsumptionBehavior consumptionBehavior = KeyConsumptionBehavior.CONSUME;
-
-		@SpecIntInRange(min = 0, max = Short.MAX_VALUE)
-		@TOMLConfigSerializer.Comment({
-				"The amount by which the key item should be consumed.",
-				"If the key item cannot be consumed this many times, the death chest will not " +
-						"be unlocked.",
-				"Players in creative mode will not have their key item consumed."
-		})
-		@ConfigEntry.Gui.Tooltip
-		public int amountToConsume = 1;
-
-		@TOMLConfigSerializer.Comment({
-				"The message that is sent to the player when they fail to unlock a death chest.",
-				"This string takes the required amount (%1$s) and display name (%2$s) of the " +
-						"item as arguments.",
-				"Set this to an empty string to disable this message."
-		})
-		@ConfigEntry.Gui.Tooltip
-		public String unlockFailureMessage = "You need %s of %s to retrieve your items";
-
-		@TOMLConfigSerializer.Comment(
-				"Whether the unlock failed message should be sent as a status message rather " +
-						"than a chat message."
-		)
-		@ConfigEntry.Gui.Tooltip
-		public boolean unlockFailureStatusMessage = true;
-
-		@Nullable
-		@ConfigEntry.Gui.Excluded
-		public Item item;
-
-		/**
-		 * {@inheritDoc}
-		 */
-		@Override
-		public void validatePostLoad() {
-			if (!registryName.isEmpty()) {
-				item = Registry.ITEM.get(new Identifier(registryName));
-
-				if (item == Items.AIR) {
-					registryName = "";
-					item = null;
-				} else {
-					registryName = new Identifier(registryName).toString();
-				}
-			}
-		}
-	}
-
-	public static final class DefenseEntities implements ConfigData {
-		@TOMLConfigSerializer.Comment({
-				"The registry name of the defense entity.",
-				"If the defense entity is a living entity, it will not automatically despawn.",
-				"If the defense entity can have a revenge target, then the revenge target will " +
-						"be set to its player.",
-				"Set this to an empty string to disable defense entities."
-		})
-		@ConfigEntry.Gui.Tooltip
-		public String registryName = "";
-
-		@TOMLConfigSerializer.Comment("Custom NBT data for defense entities in JSON format.")
-		@ConfigEntry.Gui.Tooltip
-		public String nbtTag = "{}";
-
-		@TOMLConfigSerializer.Comment("Causes defense entities to drop experience.")
-		@ConfigEntry.Gui.Tooltip
-		public boolean dropExperience;
-
-		@TOMLConfigSerializer.Comment("Causes defense entities to drop items.")
-		@ConfigEntry.Gui.Tooltip
-		public boolean dropItems;
-
-		@SpecIntInRange(min = 1, max = Integer.MAX_VALUE)
-		@TOMLConfigSerializer.Comment(
-				"The number of defense entities that are spawned when a death chest is placed."
-		)
-		@ConfigEntry.Gui.Tooltip
-		public int spawnCount = 3;
-
-		@SpecDoubleInRange(min = 0.0, max = Double.MAX_VALUE)
-		@TOMLConfigSerializer.Comment({
-				"The maximum squared distance that a defense entity can be from its chest when " +
-						"a player is not nearby.",
-				"Set this to 0.0 to disable the limit so that defense entities are not " +
-						"teleported back to their death chest."
-		})
-		@ConfigEntry.Gui.Tooltip
-		public double maxSquaredDistanceFromChest = 64.0;
-
-		@SpecDoubleInRange(min = 0.0, max = Double.MAX_VALUE)
-		@TOMLConfigSerializer.Comment({
-				"The maximum squared distance that a defense entity can be from its player when" +
-						"its chest is not within the maximum squared distance.",
-				"Set this to 0.0 to disable the limit so that defense entities are teleported " +
-						"back to their death chest regardless of their distance from the player."
-		})
-		@ConfigEntry.Gui.Tooltip
-		public double maxSquaredDistanceFromPlayer = 64.0;
-
-		@Nullable
-		@ConfigEntry.Gui.Excluded
-		public EntityType<? extends Entity> entityType;
-
-		/**
-		 * {@inheritDoc}
-		 */
-		@Override
-		public void validatePostLoad() {
-			if (!registryName.isEmpty()) {
-				final Optional<EntityType<?>> optional =
-						Registry.ENTITY_TYPE.getOrEmpty(new Identifier(registryName));
-
-				if (optional.isPresent()) {
-					registryName = new Identifier(registryName).toString();
-					entityType = optional.get();
-				} else {
-					registryName = "";
-					entityType = null;
-				}
-			}
-
-			try {
-				StringNbtReader.parse(nbtTag);
-			} catch (CommandSyntaxException ex) {
-				nbtTag = "{}";
-			}
-		}
-	}
-
-	public static final class Protection {
-		@TOMLConfigSerializer.Comment({
-				"Enables death chest protection.",
-				"When a death chest is protected, it can only be unlocked by its owner."
-		})
-		@ConfigEntry.Gui.Tooltip
-		public boolean enable = true;
-
-		@SpecIntInRange(min = 0, max = Integer.MAX_VALUE)
-		@TOMLConfigSerializer.Comment(
-				"The required permission level to bypass death chest protection."
-		)
-		@ConfigEntry.Gui.Tooltip
-		public int bypassPermissionLevel = 3;
-
-		@TOMLConfigSerializer.Comment(
-				"Causes players in creative mode to be able to bypass death chest protection."
-		)
-		@ConfigEntry.Gui.Tooltip
-		public boolean bypassInCreativeMode = true;
-
-		@SpecIntInRange(min = 0, max = Integer.MAX_VALUE)
-		@TOMLConfigSerializer.Comment({
-				"The length of death chest protection in ticks.",
-				"120000 ticks is five in-game days.",
-				"Set this to 0 to cause death chests to be protected indefinitely."
-		})
-		@ConfigEntry.Gui.Tooltip
-		public int period = 120000;
-	}
-
-	public static final class Misc {
-		@TOMLConfigSerializer.Comment("Causes death chests to be removed when they are emptied.")
-		@ConfigEntry.Gui.Tooltip
-		public boolean removeEmptyDeathChests = true;
-
-		@TOMLConfigSerializer.Comment(
-				"Whether empty death chests should only be removed when they are closed."
-		)
-		@ConfigEntry.Gui.Tooltip
-		public boolean onlyRemoveClosedEmptyDeathChests;
-
-		@TOMLConfigSerializer.Comment("Causes death chests to be dropped when they are broken.")
-		@ConfigEntry.Gui.Tooltip
-		public boolean dropDeathChests;
-
-		@TOMLConfigSerializer.Comment({
-				"The name of the game rule that controls whether death chests should be spawned.",
-				"Set this to an empty string to disable the game rule.",
-				"Changes to this option are applied after a game restart."
-		})
-		@ConfigEntry.Gui.Tooltip
-		public String gameRuleName = "spawnDeathChests";
-
-		@TOMLConfigSerializer.Comment({
-				"The name of the command that reloads this configuration from disk.",
-				"Set this to an empty string to disable the command.",
-				"Changes to this option are applied when a server is loaded."
-		})
-		@ConfigEntry.Gui.Tooltip
-		public String configReloadCommand = "vdcconfigreload";
-	}
+	@ConfigEntry.Category("misc")
+	@ConfigEntry.Gui.TransitiveObject
+	public Misc misc = new Misc();
 
 	/**
 	 * The death chest container type.
@@ -553,29 +200,4 @@ public final class VDCConfig implements ConfigData {
 		 */
 		DAMAGE
 	}
-
-	@TOMLConfigSerializer.Comment("Options related to death chest spawning.")
-	@ConfigEntry.Category("spawning")
-	@ConfigEntry.Gui.TransitiveObject
-	public Spawning spawning = new Spawning();
-
-	@TOMLConfigSerializer.Comment("Options related to the death chest key item.")
-	@ConfigEntry.Category("key_item")
-	@ConfigEntry.Gui.TransitiveObject
-	public KeyItem keyItem = new KeyItem();
-
-	@TOMLConfigSerializer.Comment("Options related to death chest defense entities.")
-	@ConfigEntry.Category("defense_entities")
-	@ConfigEntry.Gui.TransitiveObject
-	public DefenseEntities defenseEntities = new DefenseEntities();
-
-	@TOMLConfigSerializer.Comment("Options related to death chest protection.")
-	@ConfigEntry.Category("protection")
-	@ConfigEntry.Gui.TransitiveObject
-	public Protection protection = new Protection();
-
-	@TOMLConfigSerializer.Comment("Miscellaneous options.")
-	@ConfigEntry.Category("misc")
-	@ConfigEntry.Gui.TransitiveObject
-	public Misc misc = new Misc();
 }

--- a/src/main/java/com/therandomlabs/vanilladeathchest/VDCModMenuEntryPoint.java
+++ b/src/main/java/com/therandomlabs/vanilladeathchest/VDCModMenuEntryPoint.java
@@ -23,9 +23,9 @@
 
 package com.therandomlabs.vanilladeathchest;
 
-import io.github.prospector.modmenu.api.ConfigScreenFactory;
-import io.github.prospector.modmenu.api.ModMenuApi;
-import me.sargunvohra.mcmods.autoconfig1u.AutoConfig;
+import com.terraformersmc.modmenu.api.ConfigScreenFactory;
+import com.terraformersmc.modmenu.api.ModMenuApi;
+import me.shedaniel.autoconfig.AutoConfig;
 
 /**
  * The Mod Menu entry point for VanillaDeathChest.

--- a/src/main/java/com/therandomlabs/vanilladeathchest/command/VDCCommand.java
+++ b/src/main/java/com/therandomlabs/vanilladeathchest/command/VDCCommand.java
@@ -140,7 +140,7 @@ public final class VDCCommand {
 			Collection<ServerPlayerEntity> players
 	) throws CommandSyntaxException {
 		for (ServerPlayerEntity player : players) {
-			final PlayerInventory inventory = player.inventory;
+			final PlayerInventory inventory = player.getInventory();
 
 			for (int i = 0; i < inventory.size(); i++) {
 				inventory.setStack(i, deathChest.getInventory().getStack(i).copy());

--- a/src/main/java/com/therandomlabs/vanilladeathchest/config/DefenseEntities.java
+++ b/src/main/java/com/therandomlabs/vanilladeathchest/config/DefenseEntities.java
@@ -1,0 +1,93 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021 TheRandomLabs
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package com.therandomlabs.vanilladeathchest.config;
+
+import java.util.Optional;
+
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import me.shedaniel.autoconfig.ConfigData;
+import me.shedaniel.autoconfig.annotation.Config;
+import me.shedaniel.autoconfig.annotation.ConfigEntry;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityType;
+import net.minecraft.nbt.StringNbtReader;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.registry.Registry;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+@Config(name = "defense_entities")
+public final class DefenseEntities implements ConfigData {
+	@ConfigEntry.Gui.Tooltip
+	public String registryName = "";
+
+	@ConfigEntry.Gui.Tooltip
+	public String nbtTag = "{}";
+
+	@ConfigEntry.Gui.Tooltip
+	public boolean dropExperience;
+
+	@ConfigEntry.Gui.Tooltip
+	public boolean dropItems;
+
+	@ConfigEntry.BoundedDiscrete(min = 1, max = Integer.MAX_VALUE)
+	@ConfigEntry.Gui.Tooltip
+	public int spawnCount = 3;
+
+	@ConfigEntry.BoundedDiscrete(min = 0, max = (long) Double.MAX_VALUE)
+	@ConfigEntry.Gui.Tooltip
+	public double maxSquaredDistanceFromChest = 64.0;
+
+	@ConfigEntry.BoundedDiscrete(min = 0, max = (long) Double.MAX_VALUE)
+	@ConfigEntry.Gui.Tooltip
+	public double maxSquaredDistanceFromPlayer = 64.0;
+
+	@Nullable
+	@ConfigEntry.Gui.Excluded
+	public EntityType<? extends Entity> entityType;
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public void validatePostLoad() {
+		if (!registryName.isEmpty()) {
+			final Optional<EntityType<?>> optional =
+					Registry.ENTITY_TYPE.getOrEmpty(new Identifier(registryName));
+
+			if (optional.isPresent()) {
+				registryName = new Identifier(registryName).toString();
+				entityType = optional.get();
+			} else {
+				registryName = "";
+				entityType = null;
+			}
+		}
+
+		try {
+			StringNbtReader.parse(nbtTag);
+		} catch (CommandSyntaxException ex) {
+			nbtTag = "{}";
+		}
+	}
+}

--- a/src/main/java/com/therandomlabs/vanilladeathchest/config/KeyItem.java
+++ b/src/main/java/com/therandomlabs/vanilladeathchest/config/KeyItem.java
@@ -1,0 +1,79 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021 TheRandomLabs
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package com.therandomlabs.vanilladeathchest.config;
+
+import com.therandomlabs.vanilladeathchest.VDCConfig;
+import me.shedaniel.autoconfig.ConfigData;
+import me.shedaniel.autoconfig.annotation.Config;
+import me.shedaniel.autoconfig.annotation.ConfigEntry;
+import net.minecraft.item.Item;
+import net.minecraft.item.Items;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.registry.Registry;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+@Config(name = "key_item")
+public final class KeyItem implements ConfigData {
+	@ConfigEntry.Gui.Tooltip
+	public String registryName = "";
+
+	@ConfigEntry.BoundedDiscrete(min = 0, max = Short.MAX_VALUE)
+	@ConfigEntry.Gui.Tooltip
+	public int meta = Short.MAX_VALUE;
+
+	@ConfigEntry.Gui.Tooltip
+	public VDCConfig.KeyConsumptionBehavior
+			consumptionBehavior = VDCConfig.KeyConsumptionBehavior.CONSUME;
+
+	@ConfigEntry.BoundedDiscrete(min = 0, max = Short.MAX_VALUE)
+	@ConfigEntry.Gui.Tooltip
+	public int amountToConsume = 1;
+
+	@ConfigEntry.Gui.Tooltip
+	public String unlockFailureMessage = "You need %s of %s to retrieve your items";
+
+	@ConfigEntry.Gui.Tooltip
+	public boolean unlockFailureStatusMessage = true;
+
+	@Nullable
+	@ConfigEntry.Gui.Excluded
+	public Item item;
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public void validatePostLoad() {
+		if (!registryName.isEmpty()) {
+			item = Registry.ITEM.get(new Identifier(registryName));
+
+			if (item == Items.AIR) {
+				registryName = "";
+				item = null;
+			} else {
+				registryName = new Identifier(registryName).toString();
+			}
+		}
+	}
+}

--- a/src/main/java/com/therandomlabs/vanilladeathchest/config/Misc.java
+++ b/src/main/java/com/therandomlabs/vanilladeathchest/config/Misc.java
@@ -21,17 +21,26 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package com.therandomlabs.vanilladeathchest.mixin;
+package com.therandomlabs.vanilladeathchest.config;
 
-import java.util.List;
+import me.shedaniel.autoconfig.ConfigData;
+import me.shedaniel.autoconfig.annotation.Config;
+import me.shedaniel.autoconfig.annotation.ConfigEntry;
 
-import net.minecraft.block.entity.BlockEntity;
-import net.minecraft.world.World;
-import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.gen.Accessor;
+@Config(name = "misc")
+public final class Misc implements ConfigData {
+	@ConfigEntry.Gui.Tooltip
+	public boolean removeEmptyDeathChests = true;
 
-@Mixin(World.class)
-public interface WorldAccessor {
-	@Accessor
-	List<BlockEntity> getUnloadedBlockEntities();
+	@ConfigEntry.Gui.Tooltip
+	public boolean onlyRemoveClosedEmptyDeathChests;
+
+	@ConfigEntry.Gui.Tooltip
+	public boolean dropDeathChests;
+
+	@ConfigEntry.Gui.Tooltip
+	public String gameRuleName = "spawnDeathChests";
+
+	@ConfigEntry.Gui.Tooltip
+	public String configReloadCommand = "vdcconfigreload";
 }

--- a/src/main/java/com/therandomlabs/vanilladeathchest/config/Protection.java
+++ b/src/main/java/com/therandomlabs/vanilladeathchest/config/Protection.java
@@ -21,27 +21,25 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package com.therandomlabs.vanilladeathchest.mixin;
+package com.therandomlabs.vanilladeathchest.config;
 
-import com.therandomlabs.vanilladeathchest.util.ViewerCount;
-import net.minecraft.block.entity.ChestBlockEntity;
-import net.minecraft.block.entity.ChestStateManager;
-import org.spongepowered.asm.mixin.Final;
-import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
+import me.shedaniel.autoconfig.ConfigData;
+import me.shedaniel.autoconfig.annotation.Config;
+import me.shedaniel.autoconfig.annotation.ConfigEntry;
 
-@Mixin(ChestBlockEntity.class)
-public final class ChestBlockEntityMixin implements ViewerCount {
-	@SuppressWarnings("PMD.AvoidProtectedFieldInFinalClass")
-	@Final
-	@Shadow
-	private ChestStateManager stateManager;
+@Config(name = "protection")
+public final class Protection implements ConfigData {
+	@ConfigEntry.Gui.Tooltip
+	public boolean enable = true;
 
-	/**
-	 * {@inheritDoc}
-	 */
-	@Override
-	public int getViewerCount() {
-		return stateManager.getViewerCount();
-	}
+	@ConfigEntry.BoundedDiscrete(min = 0, max = Integer.MAX_VALUE)
+	@ConfigEntry.Gui.Tooltip
+	public int bypassPermissionLevel = 3;
+
+	@ConfigEntry.Gui.Tooltip
+	public boolean bypassInCreativeMode = true;
+
+	@ConfigEntry.BoundedDiscrete(min = 0, max = Integer.MAX_VALUE)
+	@ConfigEntry.Gui.Tooltip
+	public int period = 120000;
 }

--- a/src/main/java/com/therandomlabs/vanilladeathchest/config/Spawning.java
+++ b/src/main/java/com/therandomlabs/vanilladeathchest/config/Spawning.java
@@ -1,0 +1,124 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021 TheRandomLabs
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package com.therandomlabs.vanilladeathchest.config;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import com.therandomlabs.vanilladeathchest.VDCConfig;
+import com.therandomlabs.vanilladeathchest.VanillaDeathChest;
+import me.shedaniel.autoconfig.ConfigData;
+import me.shedaniel.autoconfig.annotation.Config;
+import me.shedaniel.autoconfig.annotation.ConfigEntry;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.registry.Registry;
+import net.minecraft.world.World;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+@Config(name = "spawning")
+public final class Spawning implements ConfigData {
+	@ConfigEntry.Gui.Tooltip
+	public VDCConfig.ContainerType containerType = VDCConfig.ContainerType.SINGLE_OR_DOUBLE_CHEST;
+
+	@ConfigEntry.Gui.Tooltip
+	public VDCConfig.ShulkerBoxColor shulkerBoxColor = VDCConfig.ShulkerBoxColor.WHITE;
+
+	@ConfigEntry.Gui.Tooltip
+	public List<String> dimensions = new ArrayList<>();
+
+	@ConfigEntry.Gui.Tooltip
+	public VDCConfig.DimensionListBehavior dimensionsBehavior =
+			VDCConfig.DimensionListBehavior.BLACKLIST;
+
+	@ConfigEntry.BoundedDiscrete(min = 1, max = Integer.MAX_VALUE)
+	@ConfigEntry.Gui.Tooltip
+	public int locationSearchRadius = 8;
+
+	@ConfigEntry.Gui.Tooltip
+	public boolean forcePlacementIfNoSuitableLocation = true;
+
+	@ConfigEntry.Gui.Tooltip
+	public boolean requirePlacementOnSolidBlocks;
+
+	@ConfigEntry.Gui.Tooltip
+	public String registryNameRegex = ".+";
+
+	@ConfigEntry.Gui.Tooltip
+	public boolean useContainerInInventory;
+
+	@ConfigEntry.Gui.Tooltip
+	public String containerDisplayName = "Death Chest";
+
+	@ConfigEntry.Gui.Tooltip
+	public String spawnMessage = "Death chest spawned at [%s, %s, %s]";
+
+	@Nullable
+	@ConfigEntry.Gui.Excluded
+	private Set<Identifier> dimensionIdentifiers;
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public void validatePostLoad() {
+		System.out.println("validating postload \n\n\n");
+		dimensionIdentifiers = dimensions.stream().
+				map(Identifier::new).
+				collect(Collectors.toSet());
+		dimensions = dimensionIdentifiers.stream().
+				map(Identifier::toString).
+				collect(Collectors.toList());
+	}
+
+	/**
+	 * Returns whether death chest spawning is enabled in the specified world's dimension.
+	 *
+	 * @param world a {@link World}.
+	 * @return {@code true} if death chest spawning is enabled in the specified dimension,
+	 * or otherwise {@code false}.
+	 */
+	@SuppressWarnings({"ConstantConditions", "NullAway"})
+	public boolean isDimensionEnabled(World world) {
+		final Identifier identifier = world.getRegistryManager().
+				get(Registry.DIMENSION_TYPE_KEY).
+				getId(world.getDimension());
+
+		if (identifier == null) {
+			VanillaDeathChest.logger.error(
+					"Failed to determine dimension", new RuntimeException()
+			);
+			return dimensionsBehavior == VDCConfig.DimensionListBehavior.BLACKLIST;
+		}
+
+		final boolean anyMatch = dimensionIdentifiers.stream().anyMatch(identifier::equals);
+
+		if (dimensionsBehavior == VDCConfig.DimensionListBehavior.BLACKLIST) {
+			return !anyMatch;
+		}
+
+		return anyMatch;
+	}
+}

--- a/src/main/java/com/therandomlabs/vanilladeathchest/deathchest/DeathChest.java
+++ b/src/main/java/com/therandomlabs/vanilladeathchest/deathchest/DeathChest.java
@@ -27,8 +27,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
-import com.therandomlabs.vanilladeathchest.VDCConfig;
 import com.therandomlabs.vanilladeathchest.VanillaDeathChest;
+import com.therandomlabs.vanilladeathchest.config.Protection;
 import com.therandomlabs.vanilladeathchest.util.DeathChestBlockEntity;
 import com.therandomlabs.vanilladeathchest.world.DeathChestsState;
 import net.fabricmc.fabric.api.util.NbtType;
@@ -37,10 +37,10 @@ import net.minecraft.entity.EntityType;
 import net.minecraft.entity.ItemEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.entity.player.PlayerInventory;
-import net.minecraft.nbt.CompoundTag;
-import net.minecraft.nbt.ListTag;
+import net.minecraft.nbt.NbtCompound;
+import net.minecraft.nbt.NbtElement;
 import net.minecraft.nbt.NbtHelper;
-import net.minecraft.nbt.Tag;
+import net.minecraft.nbt.NbtList;
 import net.minecraft.server.OperatorEntry;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.util.math.BlockPos;
@@ -201,7 +201,7 @@ public final class DeathChest {
 	public boolean exists() {
 		//We don't bother checking the east block, as it is impossible to only break one
 		//block in a double death chest.
-		if (!world.getBlockState(pos).getBlock().hasBlockEntity()) {
+		if (!world.getBlockState(pos).hasBlockEntity()) {
 			return false;
 		}
 
@@ -220,10 +220,10 @@ public final class DeathChest {
 	 */
 	@SuppressWarnings("ConstantConditions")
 	public boolean isProtectedFrom(PlayerEntity player) {
-		final VDCConfig.Protection config = VanillaDeathChest.config().protection;
+		final Protection config = VanillaDeathChest.getConfig().protection;
 
 		if (!config.enable || playerUUID.equals(player.getUuid()) ||
-				(config.bypassInCreativeMode && player.abilities.creativeMode)) {
+				(config.bypassInCreativeMode && player.getAbilities().creativeMode)) {
 			return false;
 		}
 
@@ -239,27 +239,27 @@ public final class DeathChest {
 	}
 
 	/**
-	 * Serializes this death chest to a {@link CompoundTag}.
+	 * Serializes this death chest to a {@link NbtCompound}.
 	 *
-	 * @param tag a {@link CompoundTag}.
-	 * @return the {@link CompoundTag}.
+	 * @param tag a {@link NbtCompound}.
+	 * @return the {@link NbtCompound}.
 	 */
-	public CompoundTag toTag(CompoundTag tag) {
+	public NbtCompound toTag(NbtCompound tag) {
 		tag.put("Identifier", NbtHelper.fromUuid(identifier));
 		tag.put("PlayerUUID", NbtHelper.fromUuid(playerUUID));
 
-		final ListTag itemsList = new ListTag();
+		final NbtList itemsList = new NbtList();
 
 		for (ItemEntity item : items) {
-			final CompoundTag itemTag = item.toTag(new CompoundTag());
-			item.writeCustomDataToTag(itemTag);
+			final NbtCompound itemTag = item.writeNbt(new NbtCompound());
+			item.writeCustomDataToNbt(itemTag);
 			itemsList.add(itemTag);
 		}
 
 		tag.put("Items", itemsList);
 
-		final ListTag inventoryList = new ListTag();
-		inventory.serialize(inventoryList);
+		final NbtList inventoryList = new NbtList();
+		inventory.writeNbt(inventoryList);
 		tag.put("Inventory", inventoryList);
 
 		tag.putLong("CreationTime", creationTime);
@@ -270,26 +270,26 @@ public final class DeathChest {
 	}
 
 	/**
-	 * Deserializes a death chest from a {@link CompoundTag}.
+	 * Deserializes a death chest from a {@link NbtCompound}.
 	 *
 	 * @param world a {@link ServerWorld}.
-	 * @param tag a {@link CompoundTag}.
+	 * @param tag a {@link NbtCompound}.
 	 * @return the deserialized {@link DeathChest}.
 	 */
 	@SuppressWarnings("ConstantConditions")
-	public static DeathChest fromTag(ServerWorld world, CompoundTag tag) {
+	public static DeathChest fromTag(ServerWorld world, NbtCompound tag) {
 		final List<ItemEntity> items = new ArrayList<>();
 
-		for (Tag itemTag : tag.getList("Items", NbtType.COMPOUND)) {
+		for (NbtElement itemTag : tag.getList("Items", NbtType.COMPOUND)) {
 			final ItemEntity item = new ItemEntity(EntityType.ITEM, world);
-			item.fromTag((CompoundTag) itemTag);
-			item.readCustomDataFromTag((CompoundTag) itemTag);
+			item.readNbt((NbtCompound) itemTag);
+			item.readCustomDataFromNbt((NbtCompound) itemTag);
 			items.add(item);
 		}
 
 		//We can pass in a null player here because deserialize doesn't use the player.
 		final PlayerInventory inventory = new PlayerInventory(null);
-		inventory.deserialize(tag.getList("Inventory", NbtType.COMPOUND));
+		inventory.readNbt(tag.getList("Inventory", NbtType.COMPOUND));
 
 		return new DeathChest(
 				NbtHelper.toUuid(tag.get("Identifier")), world,

--- a/src/main/java/com/therandomlabs/vanilladeathchest/deathchest/DeathChestAutoRemover.java
+++ b/src/main/java/com/therandomlabs/vanilladeathchest/deathchest/DeathChestAutoRemover.java
@@ -45,7 +45,7 @@ public final class DeathChestAutoRemover {
 	 * @param world a {@link ServerWorld}.
 	 */
 	public static void removeEmpty(ServerWorld world) {
-		if (!VanillaDeathChest.config().misc.removeEmptyDeathChests) {
+		if (!VanillaDeathChest.getConfig().misc.removeEmptyDeathChests) {
 			return;
 		}
 
@@ -80,7 +80,7 @@ public final class DeathChestAutoRemover {
 			}
 		}
 
-		if (!VanillaDeathChest.config().misc.onlyRemoveClosedEmptyDeathChests ||
+		if (!VanillaDeathChest.getConfig().misc.onlyRemoveClosedEmptyDeathChests ||
 				!(blockEntity instanceof ViewerCount) ||
 				((ViewerCount) blockEntity).getViewerCount() == 0) {
 			world.setBlockState(pos, Blocks.AIR.getDefaultState());

--- a/src/main/java/com/therandomlabs/vanilladeathchest/deathchest/DeathChestInteractions.java
+++ b/src/main/java/com/therandomlabs/vanilladeathchest/deathchest/DeathChestInteractions.java
@@ -25,6 +25,7 @@ package com.therandomlabs.vanilladeathchest.deathchest;
 
 import com.therandomlabs.vanilladeathchest.VDCConfig;
 import com.therandomlabs.vanilladeathchest.VanillaDeathChest;
+import com.therandomlabs.vanilladeathchest.config.KeyItem;
 import com.therandomlabs.vanilladeathchest.util.DeathChestBlockEntity;
 import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.entity.EquipmentSlot;
@@ -68,7 +69,7 @@ public final class DeathChestInteractions {
 			return ActionResult.PASS;
 		}
 
-		if (!world.getBlockState(blockHitResult.getBlockPos()).getBlock().hasBlockEntity()) {
+		if (!world.getBlockState(blockHitResult.getBlockPos()).hasBlockEntity()) {
 			return ActionResult.PASS;
 		}
 
@@ -98,7 +99,7 @@ public final class DeathChestInteractions {
 			return false;
 		}
 
-		final VDCConfig.KeyItem config = VanillaDeathChest.config().keyItem;
+		final KeyItem config = VanillaDeathChest.getConfig().keyItem;
 
 		if (config.item == null) {
 			deathChest.setLocked(false);
@@ -113,7 +114,7 @@ public final class DeathChestInteractions {
 		final int amount = config.amountToConsume;
 
 		if (stack.getItem() == config.item) {
-			if (amount == 0 || player.abilities.creativeMode) {
+			if (amount == 0 || player.getAbilities().creativeMode) {
 				deathChest.setLocked(false);
 				return true;
 			}

--- a/src/main/java/com/therandomlabs/vanilladeathchest/deathchest/DeathChestLocationFinder.java
+++ b/src/main/java/com/therandomlabs/vanilladeathchest/deathchest/DeathChestLocationFinder.java
@@ -28,8 +28,8 @@ import java.util.Iterator;
 import java.util.List;
 
 import com.google.common.collect.ImmutableList;
-import com.therandomlabs.vanilladeathchest.VDCConfig;
 import com.therandomlabs.vanilladeathchest.VanillaDeathChest;
+import com.therandomlabs.vanilladeathchest.config.Spawning;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.Blocks;
 import net.minecraft.entity.player.PlayerEntity;
@@ -138,7 +138,7 @@ public final class DeathChestLocationFinder {
 		final PlayerEntity player = world.getPlayerByUuid(deathChest.getPlayerUUID());
 		final BlockPos pos = deathChest.getPos();
 
-		final VDCConfig.Spawning config = VanillaDeathChest.config().spawning;
+		final Spawning config = VanillaDeathChest.getConfig().spawning;
 
 		final BlockPos searchPos = new BlockPos(
 				pos.getX(), Math.min(256, Math.max(1, pos.getY())), pos.getZ()
@@ -190,7 +190,7 @@ public final class DeathChestLocationFinder {
 
 	private static boolean canPlace(World world, PlayerEntity player, BlockPos pos) {
 		if (!world.canPlayerModifyAt(player, pos) ||
-				(VanillaDeathChest.config().spawning.requirePlacementOnSolidBlocks &&
+				(VanillaDeathChest.getConfig().spawning.requirePlacementOnSolidBlocks &&
 						!world.isTopSolid(pos.down(), player))) {
 			return false;
 		}

--- a/src/main/java/com/therandomlabs/vanilladeathchest/deathchest/DeathChestPlacer.java
+++ b/src/main/java/com/therandomlabs/vanilladeathchest/deathchest/DeathChestPlacer.java
@@ -377,7 +377,7 @@ public final class DeathChestPlacer {
 					continue;
 				}
 
-				final NbtCompound tag = stack.getTag();
+				final NbtCompound tag = stack.getNbt();
 
 				if (tag != null) {
 					final DefaultedList<ItemStack> inventory =

--- a/src/main/java/com/therandomlabs/vanilladeathchest/mixin/ChestBlockEntityMixin.java
+++ b/src/main/java/com/therandomlabs/vanilladeathchest/mixin/ChestBlockEntityMixin.java
@@ -25,7 +25,7 @@ package com.therandomlabs.vanilladeathchest.mixin;
 
 import com.therandomlabs.vanilladeathchest.util.ViewerCount;
 import net.minecraft.block.entity.ChestBlockEntity;
-import net.minecraft.block.entity.ChestStateManager;
+import net.minecraft.block.entity.ViewerCountManager;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -35,7 +35,7 @@ public final class ChestBlockEntityMixin implements ViewerCount {
 	@SuppressWarnings("PMD.AvoidProtectedFieldInFinalClass")
 	@Final
 	@Shadow
-	private ChestStateManager stateManager;
+	private ViewerCountManager stateManager;
 
 	/**
 	 * {@inheritDoc}

--- a/src/main/java/com/therandomlabs/vanilladeathchest/mixin/LockableContainerBlockEntityMixin.java
+++ b/src/main/java/com/therandomlabs/vanilladeathchest/mixin/LockableContainerBlockEntityMixin.java
@@ -26,10 +26,9 @@ package com.therandomlabs.vanilladeathchest.mixin;
 import com.therandomlabs.vanilladeathchest.deathchest.DeathChest;
 import com.therandomlabs.vanilladeathchest.util.DeathChestBlockEntity;
 import com.therandomlabs.vanilladeathchest.world.DeathChestsState;
-import net.minecraft.block.BlockState;
 import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.block.entity.LockableContainerBlockEntity;
-import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.NbtCompound;
 import net.minecraft.server.world.ServerWorld;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.spongepowered.asm.mixin.Mixin;
@@ -80,13 +79,13 @@ public final class LockableContainerBlockEntityMixin implements DeathChestBlockE
 		isDeathChest = true;
 	}
 
-	@Inject(method = "fromTag", at = @At("TAIL"))
-	private void fromTag(BlockState state, CompoundTag tag, CallbackInfo info) {
+	@Inject(method = "readNbt", at = @At("TAIL"))
+	private void fromTag(NbtCompound tag, CallbackInfo info) {
 		isDeathChest = tag.getBoolean("IsDeathChest");
 	}
 
-	@Inject(method = "toTag", at = @At("TAIL"))
-	private void toTag(CompoundTag tag, CallbackInfoReturnable<CompoundTag> info) {
+	@Inject(method = "writeNbt", at = @At("TAIL"))
+	private void toTag(NbtCompound tag, CallbackInfoReturnable<NbtCompound> info) {
 		if (isDeathChest) {
 			tag.putBoolean("IsDeathChest", true);
 		}

--- a/src/main/java/com/therandomlabs/vanilladeathchest/mixin/ServerPlayerInteractionManagerMixin.java
+++ b/src/main/java/com/therandomlabs/vanilladeathchest/mixin/ServerPlayerInteractionManagerMixin.java
@@ -47,7 +47,7 @@ public final class ServerPlayerInteractionManagerMixin {
 
 	@Inject(method = "tryBreakBlock", at = @At("HEAD"), cancellable = true)
 	private void tryBreakBlock(BlockPos pos, CallbackInfoReturnable<Boolean> info) {
-		if (!world.getBlockState(pos).getBlock().hasBlockEntity()) {
+		if (!world.getBlockState(pos).hasBlockEntity()) {
 			return;
 		}
 

--- a/src/main/java/com/therandomlabs/vanilladeathchest/mixin/ShulkerBoxBlockMixin.java
+++ b/src/main/java/com/therandomlabs/vanilladeathchest/mixin/ShulkerBoxBlockMixin.java
@@ -64,7 +64,7 @@ public final class ShulkerBoxBlockMixin {
 
 		final DefaultedList<ItemStack> inventory = DefaultedList.ofSize(27, ItemStack.EMPTY);
 		Inventories.readNbt(
-				((ItemEntity) entity).getStack().getTag().getCompound("BlockEntityTag"), inventory
+				((ItemEntity) entity).getStack().getNbt().getCompound("BlockEntityTag"), inventory
 		);
 
 		boolean dropped = false;

--- a/src/main/java/com/therandomlabs/vanilladeathchest/mixin/ShulkerBoxBlockMixin.java
+++ b/src/main/java/com/therandomlabs/vanilladeathchest/mixin/ShulkerBoxBlockMixin.java
@@ -50,7 +50,7 @@ public final class ShulkerBoxBlockMixin {
 			)
 	)
 	private boolean spawnEntity(World world, Entity entity) {
-		if (VanillaDeathChest.config().misc.dropDeathChests) {
+		if (VanillaDeathChest.getConfig().misc.dropDeathChests) {
 			return world.spawnEntity(entity);
 		}
 
@@ -63,7 +63,7 @@ public final class ShulkerBoxBlockMixin {
 		}
 
 		final DefaultedList<ItemStack> inventory = DefaultedList.ofSize(27, ItemStack.EMPTY);
-		Inventories.fromTag(
+		Inventories.readNbt(
 				((ItemEntity) entity).getStack().getTag().getCompound("BlockEntityTag"), inventory
 		);
 

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -27,8 +27,8 @@
 		"vanilladeathchest.mixins.json"
 	],
 	"depends": {
-		"fabricloader": ">=0.7.4",
+		"fabricloader": ">=0.11.3",
 		"fabric": "*",
-		"minecraft": "1.16.x"
+		"minecraft": "1.17.x"
 	}
 }

--- a/src/main/resources/vanilladeathchest.mixins.json
+++ b/src/main/resources/vanilladeathchest.mixins.json
@@ -12,8 +12,7 @@
 		"PlayerEntityMixin",
 		"ServerPlayerInteractionManagerMixin",
 		"ShulkerBoxBlockEntityMixin",
-		"ShulkerBoxBlockMixin",
-		"WorldAccessor"
+		"ShulkerBoxBlockMixin"
 	],
 	"injectors": {
 		"defaultRequire": 1


### PR DESCRIPTION
I've spent some time updating this mod to work on 1.17, currently as far as I can tell it works as intended. The biggest change I made was to switch the AutoConfig to use the built in JSON serializer instead of the custom TOML one, (And split the subclasses of the config into a file called 'config', though that could be reverted if desired) and I also have a custom version of [Common Gradle](https://github.com/jhbuchanan45/Common-Gradle) which I updated slightly to point to the latest versions of ModMenu and ClothConfig. (Currently the repo for ModMenu is temporary while they fix issues with their permanent repo, so that would have to change in future)
I also replaced the removed `getUnloadedBlockEntities` with a call to check if the `entity.isRemoved()` to determine if the death chest has been removed or unloaded.